### PR TITLE
Missing GitHub Actions Issue Template (MD Files)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug Report 🐞
+description: Report any bugs or issues you've encountered.
+title: "[BUG] "
+labels: bug, needs triage
+assignees: ''
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thank you for taking the time to report a bug! Please provide as much detail as possible to help us resolve the issue quickly.**
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description
+      description: Clearly describe the issue and its impact.
+      placeholder: "What happened? What did you expect to happen?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: 🔄 Steps to Reproduce
+      description: List the steps to reproduce the bug.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Observe the error
+    validations:
+      required: true
+
+  - type: input
+    id: expected-behavior
+    attributes:
+      label: ✅ Expected Behavior
+      description: What should happen instead of the issue?
+      placeholder: "Describe the correct behavior."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: ❌ Actual Behavior
+      description: What actually happened?
+      placeholder: "Describe the incorrect behavior."
+
+  - type: input
+    id: environment
+    attributes:
+      label: 🖥️ Environment
+      description: Provide details about your setup.
+      placeholder: "e.g., OS: Windows/Mac/Linux, Node.js version, Browser, etc."
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: 📂 Additional Context or Screenshots
+      description: Add any other context or attach screenshots to help us understand the issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml/cutsom.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml/cutsom.yml
@@ -1,0 +1,26 @@
+name: Custom Issue 🚀
+description: Use this template for any other type of issue.
+title: "[CUSTOM] "
+labels: needs triage
+assignees: ''
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Please provide a detailed description of your issue or request below.**
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 📝 Details
+      description: Provide as much information as possible.
+      placeholder: "Describe your issue, request, or suggestion."
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: 📂 Additional Context or Screenshots
+      description: Add any other context or attach screenshots if applicable.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml/documentation_request.yml
@@ -1,0 +1,44 @@
+name: Documentation Request 📚
+description: Contribute to the HungryBox documentation or share additional technical details.
+title: "[DOCS] "
+labels: documentation, needs triage
+assignees: ''
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thank you for helping improve HungryBox documentation! This template will guide you to suggest updates, add missing information, or share technical details.**
+
+  - type: input
+    id: doc-title
+    attributes:
+      label: 📘 Title
+      description: Provide a short and clear title for the documentation request or update.
+      placeholder: "E.g., Add setup instructions for MongoDB Atlas"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description
+      description: Describe the documentation request or improvement in detail.
+      placeholder: |
+        What part of the documentation needs improvement or addition?
+        E.g., Add steps for setting up a development environment.
+    validations:
+      required: true
+
+  - type: textarea
+    id: missing-info
+    attributes:
+      label: ❓ Missing Information
+      description: If applicable, specify what is missing in the current documentation.
+      placeholder: "E.g., No details about how to configure environment variables in backend."
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-details
+    att

--- a/.github/ISSUE_TEMPLATE/bug_report.yml/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature Request ✨
+description: Suggest a new feature or improvement for HungryBox.
+title: "[FEATURE] "
+labels: enhancement, needs triage
+assignees: ''
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thank you for suggesting a feature! Your ideas help make HungryBox even better.**
+
+  - type: input
+    id: feature-title
+    attributes:
+      label: 💡 Feature Title
+      description: Give your feature a short and clear title.
+      placeholder: "E.g., Add dark mode support"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description
+      description: Describe the feature or improvement you’re suggesting.
+      placeholder: "What problem does this feature solve? How would it improve HungryBox?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: 🔍 Use Case
+      description: Explain how this feature would be used or why it is valuable.
+      placeholder: "E.g., This feature would allow users to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: 📂 Additional Context or Screenshots
+      description: Add any other details or screenshots to help us understand your suggestion.


### PR DESCRIPTION
The repository currently lacks a dedicated GitHub Actions issue template in markdown format, which is essential for reporting issues related to the CI/CD pipeline. Having a GitHub Actions issue template would enable contributors to provide structured information, including error messages, steps to reproduce the issue, affected workflows, 

Closes #40