### PR TITLE
[FIX] Fixed Subscription Page not being accessible without logging in

### DIFF
--- a/frontend/src/components/Navbar/Navbar.js
+++ b/frontend/src/components/Navbar/Navbar.js
@@ -22,7 +22,7 @@ const Navbar = ({ setShowLogin }) => {
   }, [setToken, navigate]);
 
   useEffect(() => {
-    if (!token) {
+    if (!token && window.location.pathname !== '/subscription') { // this allows the subscription page to be opened without logging in
       navigate("/");
     }
   }, [token, navigate]);


### PR DESCRIPTION
## Related Issue:
**FIXES #81** 
This issue states that the subscription page not showing. I checked and noticed that the subscription page is accessible, but only when the user is logged in. However, it is better for the user experience to allow users to access the subscription page without having to log in.

## Changes Made:
- Changed useEffect()
![image](https://github.com/user-attachments/assets/dfa02e3c-f578-4be2-bede-bb3d7a0e5e17)
- moved the Subscription link's code block out of conditional rendering
- now the subscription menu item will be visible and clickable for all users

## Type of Change:
- [X] Bugfix
- [ ] New Feature
- [ ] Improvement
- [ ] Documentation Update

## Attachments:
https://github.com/user-attachments/assets/7e2ef0c7-44f5-4533-9b71-5e1651146d17

### Thank you!