### PR TITLE
[FIX] Fixed overlapping sticky navbar

### DIFF
--- a/frontend/src/components/Navbar/Navbar.css
+++ b/frontend/src/components/Navbar/Navbar.css
@@ -4,8 +4,9 @@
   justify-content: space-evenly;
   align-items: center;
   color: #fff;
-  position: sticky;
-  top: 0;
+  /* Remove sticky positioning */
+  /* position: sticky; */
+  /* top: 0; */
   z-index: 1000;
 }
 


### PR DESCRIPTION
## Related Issue
fixes issue #80 

## Changes Made
- The issue states that the navbar should remain at top. On testing, I noticed that the problem was with the navbar being sticky.
- This made it overlap over the page's elements and take up more space than necessary on the page.
- I made it so that the navbar stopped being sticky, and stays at the top of the page, hence not interfering with the user experience when it comes to scrolling.

## Type of Change
- [X] Bugfix
- [ ] New Feature
- [ ] Improvement
- [ ] Documentation Update

## Attachments:

https://github.com/user-attachments/assets/7220ed39-2f77-4bec-9af3-10fd7ec331bf

