### PR TITLE
(style) made explore menue easier to read

### DIFF
--- a/frontend/src/components/ExploreMenu/ExploreMenu.css
+++ b/frontend/src/components/ExploreMenu/ExploreMenu.css
@@ -6,20 +6,27 @@
 }
 
 .explore-menu h1 {
-  color: #6F4E37;
+  color: #eab76c;
   font-weight: 500;
   text-align: center;
   margin-top: 25px;
-  font-size: 40px;
+  font-size: 45px;
 }
 
 .explore-menu .explore-menu-text {
   max-width: 80%;
-  color: #808080;
+  color: var(--text-color);
   text-align: center;
   margin-left: auto;
   margin-right: auto;
-  font-size: 17px;
+  font-size: 20px;
+  text-shadow: 0 1px 2px gray;
+ 
+}
+
+.explore-menu-text{
+  color: white;
+  text-shadow: 0px .5px 0px black;
 }
 
 .explore-menu-list {
@@ -31,22 +38,31 @@
   margin: 20px 0;
   overflow-x: auto;
   padding-bottom: 10px;
+ 
 }
 
 .explore-menu-list::-webkit-scrollbar {
   display: none;
 }
 
+
 .explore-menu-list-item {
   display: flex;
   flex-direction: column;
   align-items: center;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
+  background-color: var(--background-color-menu);
+  padding: 20px;
+  margin: 5px;
+  margin-top: 15px;
+  border-radius: 10%;
+  box-shadow: 0 1px 5px var(--shadow-menu);
+
+  
 }
 
 .explore-menu-list-item:hover {
   transform: translateY(-10px);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
 }
 
 .explore-menu-list-item img {
@@ -55,12 +71,13 @@
   cursor: pointer;
   border-radius: 50%;
   transition: 0.2s;
-  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+  box-shadow: #eab76c 0 0 0 1.5px;
+  
 }
 
 .explore-menu-list-item p {
   margin-top: 10px;
-  color: #6F4E37;
+  color: var(--text-color-menu);
   font-size: max(1.4vw, 16px);
   cursor: pointer;
   font-family: pacifico;
@@ -76,6 +93,7 @@
 
 .explore-menu-list-item .active {
   border: 4px solid rgb(48, 67, 114);
+  box-shadow: #eab76c 0 0 0 0;
   padding: 2px;
   animation: pulse 0.6s infinite alternate;
 }

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -2,12 +2,18 @@
   --background-color: #ffffff;
   --text-color: #000000;
   --primary-color: #007bff;
+  --background-color-menu: #faefda;
+  --text-color-menu: #cd7a29;
+  --shadow-menu: #cd7a29;
 }
 
 [data-theme="dark"] {
   --background-color: #121212;
   --text-color: #ffffff;
   --primary-color: #bb86fc;
+  --background-color-menu: black;
+  --text-color-menu: #eab76c;
+  --shadow-menu: #eab76c;
 }
 
 /* Global Styles */


### PR DESCRIPTION
# Pull Request Template

## Description
for this PR I was trying to make the text for ExploreMenu easier to read, my original plan was to add a text shadow but with the background image it still wasn't very readable so I ended up adding a background color for the menu list items and adjust the text color.

### What kind of change does this PR introduce?

- [ x] Feature enhancement


## Related Issue
<!-- Link the issue this PR addresses (e.g. #123) -->
Closes Text Readability #144

## How Has This Been Tested?
<!-- Please describe the tests that were run to verify this change. -->

- [ x] Manual testing (include steps if needed)

ensured text was essay to read on both dark and light mode 

## Screenshots (if applicable):
<!-- Add any relevant screenshots here to showcase your changes. -->
Previous: 
![image](https://github.com/user-attachments/assets/d10e7b6d-da79-4c62-b130-009119a1db7f)
![image](https://github.com/user-attachments/assets/c992dda5-526f-4d61-ba92-6c210a3c8077)



Current:
![image](https://github.com/user-attachments/assets/b8670ea6-cd27-40e0-9476-33092c6625b7)
![image](https://github.com/user-attachments/assets/3432ec88-79ea-4b7f-ace1-6cee67382bbf)


## Checklist:

- [x ] My code follows the project's code style guidelines.

